### PR TITLE
feat: トップページにウェルカムスクリーンと Quickstart 機能を追加

### DIFF
--- a/apps/frontend/src/components/main/MainArea.tsx
+++ b/apps/frontend/src/components/main/MainArea.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom';
 import { MainHeader } from './MainHeader';
 import { MessageArea } from './MessageArea';
 import { InputArea } from './InputArea';
+import { WelcomeScreen } from './WelcomeScreen';
 import { useSessionEvents } from '@/hooks/useSessionEvents';
 import { useSession } from '@/hooks/useSession';
 
@@ -35,6 +36,15 @@ export function MainArea({ branchName, onSendMessage, onSessionArchived }: MainA
     await updateSession({ session_status: 'archived' });
     onSessionArchived?.();
   };
+
+  // セッション未選択時はウェルカムスクリーンを表示
+  if (!sessionId) {
+    return (
+      <div className="relative z-0 flex flex-col w-full h-full min-w-0 overflow-hidden bg-background">
+        <WelcomeScreen />
+      </div>
+    );
+  }
 
   return (
     <div className="relative z-0 flex flex-col w-full h-full min-w-0 overflow-hidden bg-background">

--- a/apps/frontend/src/components/main/QuickstartCard.tsx
+++ b/apps/frontend/src/components/main/QuickstartCard.tsx
@@ -1,0 +1,31 @@
+import { LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface QuickstartCardProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  onClick: () => void;
+}
+
+export function QuickstartCard({ icon: Icon, title, description, onClick }: QuickstartCardProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'w-full p-4 rounded-lg border border-border bg-card',
+        'flex items-start gap-4 text-left',
+        'transition-colors hover:bg-accent hover:border-accent-foreground/20',
+        'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2'
+      )}
+    >
+      <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted shrink-0">
+        <Icon className="h-5 w-5 text-muted-foreground" />
+      </div>
+      <div className="min-w-0">
+        <h3 className="font-medium text-foreground">{title}</h3>
+        <p className="text-sm text-muted-foreground line-clamp-2">{description}</p>
+      </div>
+    </button>
+  );
+}

--- a/apps/frontend/src/components/main/QuickstartModal.tsx
+++ b/apps/frontend/src/components/main/QuickstartModal.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next';
+import { Construction } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+export type QuickstartType = 'lakeflow' | 'unityCatalog' | 'databricksApps';
+
+interface QuickstartModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  quickstartType: QuickstartType | null;
+}
+
+export function QuickstartModal({ open, onOpenChange, quickstartType }: QuickstartModalProps) {
+  const { t } = useTranslation();
+
+  if (!quickstartType) return null;
+
+  const titleKey = `welcome.quickstarts.${quickstartType}.title`;
+  const modalDescKey = `welcome.quickstarts.${quickstartType}.modalDescription`;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t(titleKey)}</DialogTitle>
+          <DialogDescription>{t(modalDescKey)}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col items-center py-8">
+          <div className="flex items-center justify-center w-16 h-16 rounded-full bg-muted mb-4">
+            <Construction className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <p className="text-sm text-muted-foreground text-center">{t('welcome.comingSoon')}</p>
+        </div>
+
+        <div className="flex justify-end">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.cancel')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/main/WelcomeScreen.tsx
+++ b/apps/frontend/src/components/main/WelcomeScreen.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Sparkles, Bug, FileSearch, Rocket } from 'lucide-react';
+import { QuickstartCard } from './QuickstartCard';
+import { QuickstartModal, QuickstartType } from './QuickstartModal';
+
+export function WelcomeScreen() {
+  const { t } = useTranslation();
+  const [selectedQuickstart, setSelectedQuickstart] = useState<QuickstartType | null>(null);
+
+  const quickstarts = [
+    {
+      type: 'lakeflow' as const,
+      icon: Bug,
+      title: t('welcome.quickstarts.lakeflow.title'),
+      description: t('welcome.quickstarts.lakeflow.description'),
+    },
+    {
+      type: 'unityCatalog' as const,
+      icon: FileSearch,
+      title: t('welcome.quickstarts.unityCatalog.title'),
+      description: t('welcome.quickstarts.unityCatalog.description'),
+    },
+    {
+      type: 'databricksApps' as const,
+      icon: Rocket,
+      title: t('welcome.quickstarts.databricksApps.title'),
+      description: t('welcome.quickstarts.databricksApps.description'),
+    },
+  ];
+
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center p-8">
+      {/* Logo Icon */}
+      <div className="flex items-center justify-center w-16 h-16 rounded-2xl bg-primary/10 mb-6">
+        <Sparkles className="h-8 w-8 text-primary" />
+      </div>
+
+      {/* Title */}
+      <h1 className="text-2xl font-semibold text-foreground mb-2">{t('welcome.title')}</h1>
+      <p className="text-muted-foreground text-center mb-8 max-w-md whitespace-pre-line">
+        {t('welcome.subtitle')}
+      </p>
+
+      {/* Quickstart Cards */}
+      <div className="w-full max-w-md space-y-3">
+        {quickstarts.map(qs => (
+          <QuickstartCard
+            key={qs.type}
+            icon={qs.icon}
+            title={qs.title}
+            description={qs.description}
+            onClick={() => setSelectedQuickstart(qs.type)}
+          />
+        ))}
+      </div>
+
+      {/* Quickstart Modal */}
+      <QuickstartModal
+        open={selectedQuickstart !== null}
+        onOpenChange={open => !open && setSelectedQuickstart(null)}
+        quickstartType={selectedQuickstart}
+      />
+    </div>
+  );
+}

--- a/apps/frontend/src/i18n/locales/en.json
+++ b/apps/frontend/src/i18n/locales/en.json
@@ -80,5 +80,27 @@
   "language": {
     "en": "English",
     "ja": "Japanese"
+  },
+  "welcome": {
+    "title": "Welcome to Claude Code",
+    "subtitle": "Accelerate your Databricks development with AI Agent.\nStart with a quickstart below or type a message.",
+    "comingSoon": "This feature is coming soon",
+    "quickstarts": {
+      "lakeflow": {
+        "title": "Investigate Lakeflow Jobs Errors",
+        "description": "Analyze job failures and suggest solutions",
+        "modalDescription": "Analyze error logs from Lakeflow Jobs to identify root causes and suggest fixes."
+      },
+      "unityCatalog": {
+        "title": "EDA on Unity Catalog",
+        "description": "Explore data catalog and understand schemas",
+        "modalDescription": "Perform exploratory data analysis on tables and views in Unity Catalog to understand data characteristics."
+      },
+      "databricksApps": {
+        "title": "App Development on Databricks Apps",
+        "description": "Build applications on Databricks Apps",
+        "modalDescription": "Support web application development using the Databricks Apps platform."
+      }
+    }
   }
 }

--- a/apps/frontend/src/i18n/locales/ja.json
+++ b/apps/frontend/src/i18n/locales/ja.json
@@ -80,5 +80,27 @@
   "language": {
     "en": "英語",
     "ja": "日本語"
+  },
+  "welcome": {
+    "title": "Claude Code へようこそ",
+    "subtitle": "AI Agent で Databricks での開発を加速しましょう。\n下のクイックスタートか、メッセージを入力から始めてください。",
+    "comingSoon": "この機能は近日公開予定です",
+    "quickstarts": {
+      "lakeflow": {
+        "title": "Lakeflow Jobs のエラー調査",
+        "description": "ジョブの失敗原因を分析し、解決策を提案します",
+        "modalDescription": "Lakeflow Jobs で発生したエラーのログを解析し、根本原因の特定と修正方法を提案します。"
+      },
+      "unityCatalog": {
+        "title": "Unity Catalog の EDA",
+        "description": "データカタログを探索し、スキーマを理解します",
+        "modalDescription": "Unity Catalog 内のテーブルやビューに対して探索的データ分析を実行し、データの特徴を把握します。"
+      },
+      "databricksApps": {
+        "title": "Databricks Apps でのアプリ開発",
+        "description": "Databricks Apps 上でアプリを構築します",
+        "modalDescription": "Databricks Apps プラットフォームを活用したウェブアプリケーションの開発をサポートします。"
+      }
+    }
   }
 }


### PR DESCRIPTION
## 概要

セッション未選択時（`/` 直下アクセス時）にウェルカムスクリーンを表示し、3つの Quickstart カードを追加しました。

## 変更内容

- セッション未選択時に `WelcomeScreen` コンポーネントを表示
- 3つの Quickstart カードを追加:
  - Lakeflow Jobs のエラー調査
  - Unity Catalog の EDA
  - Databricks Apps でのアプリ開発
- カードクリック時にモックモーダルを表示（将来実装用のプレースホルダー）
- 日本語/英語の i18n 対応

## 新規ファイル

| ファイル | 説明 |
|---------|------|
| `WelcomeScreen.tsx` | ウェルカムスクリーン本体 |
| `QuickstartCard.tsx` | クイックスタートカードコンポーネント |
| `QuickstartModal.tsx` | モックモーダル（近日公開予定表示） |

## スクリーンショット

<!-- 必要に応じてスクリーンショットを追加 -->

## テスト方法

1. `npm run dev` で開発サーバーを起動
2. `http://localhost:3000/` にアクセス
3. ウェルカムスクリーンと3つの Quickstart カードが表示されることを確認
4. 各カードをクリックしてモーダルが開くことを確認
5. 既存のセッション選択時は従来通り動作することを確認